### PR TITLE
Removed S3 SoC and modules due changes on the SoC pin mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ The following SoC are included in this library
 |ESP32-C3      |Yes     |No         |[Datasheet](https://www.espressif.com/sites/default/files/documentation/esp32-c3_datasheet_en.pdf)      |
 |ESP32-PICO-V3 |Yes     |No         |[Datasheet](https://www.espressif.com/sites/default/files/documentation/esp32-pico-v3_datasheet_en.pdf) |
 |ESP32-S2      |Yes     |No         |[Datasheet](https://www.espressif.com/sites/default/files/documentation/esp32-s2_datasheet_en.pdf)      |
-|ESP32-S3      |Yes     |No         |[Datasheet](https://www.espressif.com/sites/default/files/documentation/esp32-s3_datasheet_en.pdf)      |
 |ESP8286       |Yes     |No         |[Datasheet](https://www.espressif.com/sites/default/files/documentation/0a-esp8266ex_datasheet_en.pdf)  |
 |ESP8285       |Yes     |No         |[Datasheet](https://www.espressif.com/sites/default/files/documentation/0a-esp8285_datasheet_en.pdf)    |
 
@@ -43,10 +42,6 @@ The following SoC are included in this library
 |ESP32-S2-SOLO     |Yes     |Yes        |[Datasheet](https://www.espressif.com/sites/default/files/documentation/esp32-s2-solo_esp32-s2-solo-u_datasheet_en.pdf)      |
 |ESP32-S2-WROOM    |Yes     |Yes        |[Datasheet](https://www.espressif.com/sites/default/files/documentation/esp32-s2-wroom_esp32-s2-wroom-i_datasheet_en.pdf)    |
 |ESP32-S2-WROVER   |Yes     |Yes        |[Datasheet](https://www.espressif.com/sites/default/files/documentation/esp32-s2-wrover_esp32-s2-wrover-i_datasheet_en.pdf)  |
-|ESP32-S3-MINI-1   |Yes     |Yes        |[Datasheet](https://products.espressif.com/)                                                                                 |
-|ESP32-S3-MINI-1U  |Yes     |Yes        |[Datasheet](https://products.espressif.com/)                                                                                 |
-|ESP32-S3-WROOM-1  |Yes     |Yes        |[Datasheet](https://products.espressif.com/)                                                                                 |
-|ESP32-S3-WROOM-1U |Yes     |Yes        |[Datasheet](https://products.espressif.com/)                                                                                 |
 |ESP32-WROOM-32E   |Yes     |Yes        |[Datasheet](https://www.espressif.com/sites/default/files/documentation/esp32-wroom-32e_esp32-wroom-32ue_datasheet_en.pdf)   |
 |ESP32-WROOM-32UE  |Yes     |Yes        |[Datasheet](https://www.espressif.com/sites/default/files/documentation/esp32-wroom-32e_esp32-wroom-32ue_datasheet_en.pdf)   |
 |ESP32-WROVER-E    |Yes     |Yes        |[Datasheet](https://www.espressif.com/sites/default/files/documentation/esp32-wrover-e_esp32-wrover-ie_datasheet_en.pdf)     |
@@ -57,7 +52,6 @@ The following SoC are included in this library
 |:----------------:|:------:|:---------:|:----------------------------------------------------------------------------------------:|
 | ESP32-S2-Saola-1 |  Yes   |    Yes    | [Schematic](https://dl.espressif.com/dl/schematics/ESP32-S2-SAOLA-1_V1.1_schematics.pdf) |
 | ESP32-DevKitC    |  Yes   |    Yes    | [Schematic](https://dl.espressif.com/dl/schematics/esp32_devkitc_v4-sch.pdf)             |
-| ESP32-S3-DevKitC |  Yes   |    Yes    |                                                                                          |
 
 ### Contributing
 


### PR DESCRIPTION
Symbols and footprint removed for now due changes on the SoC pin mapping.

As soon as the final pin mapping is released, the symbols and footprints will be updated.