### PR TITLE
Reverted the KiCad version from 20211014 to 20220914 (#93)

### DIFF
--- a/libraries/Espressif.kicad_sym
+++ b/libraries/Espressif.kicad_sym
@@ -1,4 +1,4 @@
-(kicad_symbol_lib (version 20220914) (generator kicad_symbol_editor)
+(kicad_symbol_lib (version 20211014) (generator kicad_symbol_editor)
   (symbol "ESP32" (in_bom yes) (on_board yes)
     (property "Reference" "U" (at -30.48 40.64 0)
       (effects (font (size 1.27 1.27)) (justify left))


### PR DESCRIPTION
This PR adds the KiCad version 7 compatibility and the note for the legacy branch.

Fix #89 