### PR TITLE
Readme file updated to the KiCad version 7 and link to the legacy branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ This repository contains the Symbols, Footprint, and 3D Models for the Espressif
 
 > Notice: The libraries are provided in the hope that they will be useful but without a warranty of any kind.
 
-**The libraries in this repository are intended to be used with KiCad version 6.**
+**The libraries in this repository are intended to be used with KiCad version 7.**
+
+For the KiCad 6 legacy library, please use [this branch](https://github.com/espressif/kicad-libraries/tree/legacy_kicad6) instead.
 
 Each footprint library is stored as a directory with the .pretty suffix. The footprint files are .kicad_mod files within.
 


### PR DESCRIPTION
This PR adds the KiCad version 7 compatibility and the note for the legacy branch.

Fix https://github.com/espressif/kicad-libraries/issues/89