### PR TITLE
Add the auto-generated metadata.json on main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,3 +32,14 @@ jobs:
           asset_path: ./build/espressif-kicad-addon.zip
           asset_name: espressif-kicad-addon.zip
           asset_content_type: application/zip
+
+      - name: Include Metadata File on Main Branch
+        run: |
+          mkdir -p ./build/main
+          cp ./metadata.json ./build/main/metadata.json
+
+      - name: Commit and Push Changes to Main Branch
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: 'Add auto generated metadata.json file to the main branch'
+          branch: main


### PR DESCRIPTION
This PR adds a new step to the release process to include the auto-generated metadata file on the main branch.