### PR TITLE
Fix the GND pins of ESP32-S3-WROOM-2

### DIFF
--- a/symbols/Espressif.kicad_sym
+++ b/symbols/Espressif.kicad_sym
@@ -5459,7 +5459,7 @@
       (text "ESP32-S3-WROOM-2" (at -20.32 0 0)
         (effects (font (size 2.54 2.54)))
       )
-      (pin power_in line (at 0 -38.1 270) (length 2.54)
+      (pin power_in line (at 0 -40.64 90) (length 2.54)
         (name "GND" (effects (font (size 1.27 1.27))))
         (number "1" (effects (font (size 1.27 1.27))))
       )
@@ -5595,11 +5595,11 @@
         (name "GPIO4/TOUCH4/ADC1_CH3" (effects (font (size 1.27 1.27))))
         (number "4" (effects (font (size 1.27 1.27))))
       )
-      (pin passive line (at 0 -38.1 270) (length 2.54) hide
+      (pin passive line (at 0 -40.64 90) (length 2.54) hide
         (name "GND" (effects (font (size 1.27 1.27))))
         (number "40" (effects (font (size 1.27 1.27))))
       )
-      (pin passive line (at 0 -38.1 270) (length 2.54) hide
+      (pin passive line (at 0 -40.64 90) (length 2.54) hide
         (name "GND" (effects (font (size 1.27 1.27))))
         (number "41" (effects (font (size 1.27 1.27))))
       )


### PR DESCRIPTION
This fix is based on the existing symbol of ESP32-S3-WROOM-1
https://github.com/espressif/kicad-libraries/blob/c34529e6d16666fbc4c0d5e0ffe3109f9583508a/symbols/Espressif.kicad_sym#L5270

Before this Fix:
![图片](https://github.com/espressif/kicad-libraries/assets/62299611/d6e42a9c-d384-43e1-90de-16ffd45fc596)
After this Fix:
![图片](https://github.com/espressif/kicad-libraries/assets/62299611/10a593f2-f9f0-431a-bae4-d14fb196e784)
