### PR TITLE
Update to support KiCad 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repository contains the Symbols, Footprint, and 3D Models for the Espressif
 
 * Notice: The libraries are provided in the hope that they will be useful but without a warranty of any kind.
 
-**The libraries in this repository are intended to be used with KiCad version 7.**
+**The libraries in this repository are intended to be used with KiCad version 8.**
 
 For the KiCad 6 legacy library, please use [this branch](https://github.com/espressif/kicad-libraries/tree/legacy_kicad6) instead.
 
@@ -103,7 +103,7 @@ To install the library, you need to download the **[espressif-kicad-addon.zip](h
 
 * [Latest Release Notes and Files](https://github.com/espressif/kicad-libraries/releases/latest)
 
-For KiCad 6 and 7, you can use the following steps:
+For KiCad 6, 7 and 8 you can use the following steps:
 
 1. On KiCad, open the PCM in the main KiCad window.
 

--- a/footprints/Espressif.pretty/ESP32-C3-MINI-1.kicad_mod
+++ b/footprints/Espressif.pretty/ESP32-C3-MINI-1.kicad_mod
@@ -159,7 +159,7 @@
       )
     )
   )
-  (model "${KICAD7_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-C3-MINI-1.STEP"
+  (model "${KICAD8_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-C3-MINI-1.STEP"
     (offset (xyz -6.6 -8.37 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/footprints/Espressif.pretty/ESP32-C3-MINI-1U.kicad_mod
+++ b/footprints/Espressif.pretty/ESP32-C3-MINI-1U.kicad_mod
@@ -116,7 +116,7 @@
   (pad "51" smd rect (at 5.95 5.65 90) (size 0.7 0.7) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp 30aad354-f659-4962-8ba3-32f351d490c0))
   (pad "52" smd rect (at -5.95 5.65 90) (size 0.7 0.7) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp 206bfdd0-417d-49a5-beaa-7015cee73d7c))
   (pad "53" smd rect (at -5.95 -4.25 90) (size 0.7 0.7) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp db00ed9d-5cbd-42e1-a367-f32e41a8348a))
-  (model "${KICAD7_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-C3-MINI-1U.STEP"
+  (model "${KICAD8_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-C3-MINI-1U.STEP"
     (offset (xyz -6.6 -6.3 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/footprints/Espressif.pretty/ESP32-C3-MINI-1_HandSoldering.kicad_mod
+++ b/footprints/Espressif.pretty/ESP32-C3-MINI-1_HandSoldering.kicad_mod
@@ -146,7 +146,7 @@
       )
     )
   )
-  (model "${KICAD7_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-C3-MINI-1.STEP"
+  (model "${KICAD8_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-C3-MINI-1.STEP"
     (offset (xyz -6.6 -5.6 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/footprints/Espressif.pretty/ESP32-C3-WROOM-02.kicad_mod
+++ b/footprints/Espressif.pretty/ESP32-C3-WROOM-02.kicad_mod
@@ -95,7 +95,7 @@
       )
     )
   )
-  (model "${KICAD7_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-C3-WROOM-02.STEP"
+  (model "${KICAD8_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-C3-WROOM-02.STEP"
     (offset (xyz -9 -7 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/footprints/Espressif.pretty/ESP32-C3-WROOM-02U.kicad_mod
+++ b/footprints/Espressif.pretty/ESP32-C3-WROOM-02U.kicad_mod
@@ -59,7 +59,7 @@
   (pad "19" smd rect (at 0.91 1.55 180) (size 0.7 0.7) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp a501555e-bbc7-4b58-ad89-28a0cd3dd6d0))
   (pad "19" smd rect (at 2.06 1.55 180) (size 0.7 0.7) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp db83d0af-e085-4050-8496-fa2ebdecbd62))
   (pad "19" smd rect (at 0.91 -0.65 180) (size 0.7 0.7) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp ebadd2a5-21ab-4a7e-b5bc-6f737367e560))
-  (model "${KICAD7_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-C3-WROOM-02U.STEP"
+  (model "${KICAD8_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-C3-WROOM-02U.STEP"
     (offset (xyz -9 -7.15 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/footprints/Espressif.pretty/ESP32-C6-MINI-1.kicad_mod
+++ b/footprints/Espressif.pretty/ESP32-C6-MINI-1.kicad_mod
@@ -159,7 +159,7 @@
       )
     )
   )
-  (model "${KICAD7_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-C6-MINI-1.STEP"
+  (model "${KICAD8_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-C6-MINI-1.STEP"
     (offset (xyz -6.55 -8.3 0.5))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/footprints/Espressif.pretty/ESP32-C6-MINI-1U.kicad_mod
+++ b/footprints/Espressif.pretty/ESP32-C6-MINI-1U.kicad_mod
@@ -137,7 +137,7 @@
   (pad "51" smd rect (at 5.95 7.65 90) (size 0.7 0.7) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp 50e39e15-e0de-401a-a82b-545a6109027c))
   (pad "52" smd rect (at -5.95 7.65 90) (size 0.7 0.7) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp 90785223-6d97-4390-8591-b39e1571cb90))
   (pad "53" smd rect (at -5.95 -2.25 90) (size 0.7 0.7) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp 35506341-d62d-48a0-90e4-2b1ad79286f3))
-  (model "${KICAD7_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-C6-MINI-1U.STEP"
+  (model "${KICAD8_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-C6-MINI-1U.STEP"
     (offset (xyz -6.75 -1.2 -8.45))
     (scale (xyz 1 1 1))
     (rotate (xyz -90 0 0))

--- a/footprints/Espressif.pretty/ESP32-C6-WROOM-1.kicad_mod
+++ b/footprints/Espressif.pretty/ESP32-C6-WROOM-1.kicad_mod
@@ -108,7 +108,7 @@
       )
     )
   )
-  (model "${KICAD7_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-C6-WROOM-1.STEP"
+  (model "${KICAD8_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-C6-WROOM-1.STEP"
     (offset (xyz -9 -9.75 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/footprints/Espressif.pretty/ESP32-H2-MINI-1.kicad_mod
+++ b/footprints/Espressif.pretty/ESP32-H2-MINI-1.kicad_mod
@@ -159,7 +159,7 @@
       )
     )
   )
-  (model "${KICAD7_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-H2-MINI-1.STEP"
+  (model "${KICAD8_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-H2-MINI-1.STEP"
     (offset (xyz -6.6 -8.37 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/footprints/Espressif.pretty/ESP32-MINI-1.kicad_mod
+++ b/footprints/Espressif.pretty/ESP32-MINI-1.kicad_mod
@@ -161,7 +161,7 @@
       )
     )
   )
-  (model "${KICAD7_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-MINI-1.STEP"
+  (model "${KICAD8_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-MINI-1.STEP"
     (offset (xyz -5.9 -6.05 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/footprints/Espressif.pretty/ESP32-PICO-MINI-02_HandSoldering.kicad_mod
+++ b/footprints/Espressif.pretty/ESP32-PICO-MINI-02_HandSoldering.kicad_mod
@@ -146,7 +146,7 @@
       )
     )
   )
-  (model "${KICAD7_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-C3-MINI-1.STEP"
+  (model "${KICAD8_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-C3-MINI-1.STEP"
     (offset (xyz -6.6 -5.6 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/footprints/Espressif.pretty/ESP32-S2-MINI-1.kicad_mod
+++ b/footprints/Espressif.pretty/ESP32-S2-MINI-1.kicad_mod
@@ -169,7 +169,7 @@
       )
     )
   )
-  (model "${KICAD7_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-S2-MINI-1.STEP"
+  (model "${KICAD8_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-S2-MINI-1.STEP"
     (offset (xyz -7.7 -7.7 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/footprints/Espressif.pretty/ESP32-S2-MINI-1U.kicad_mod
+++ b/footprints/Espressif.pretty/ESP32-S2-MINI-1U.kicad_mod
@@ -127,7 +127,7 @@
   (pad "63" smd rect (at -7 7 180) (size 0.8 0.8) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp e45fcfed-f0fa-4774-a755-a370fc083a7b))
   (pad "64" smd rect (at 7 7 180) (size 0.8 0.8) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp 89c03684-f3c5-4a26-981f-c71a6f283cdf))
   (pad "65" smd rect (at 7 -7 180) (size 0.8 0.8) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp 2ea128a7-52a4-40f8-af72-c940669cdcd0))
-  (model "${KICAD7_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-S2-MINI-1U.STEP"
+  (model "${KICAD8_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-S2-MINI-1U.STEP"
     (offset (xyz -7.7 7.7 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/footprints/Espressif.pretty/ESP32-S2-MINI-1_HandSoldering.kicad_mod
+++ b/footprints/Espressif.pretty/ESP32-S2-MINI-1_HandSoldering.kicad_mod
@@ -154,7 +154,7 @@
       )
     )
   )
-  (model "${KICAD7_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-S2-MINI-1.STEP"
+  (model "${KICAD8_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-S2-MINI-1.STEP"
     (offset (xyz -7.7 -7.7 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/footprints/Espressif.pretty/ESP32-S2-SOLO-2U.kicad_mod
+++ b/footprints/Espressif.pretty/ESP32-S2-SOLO-2U.kicad_mod
@@ -94,7 +94,7 @@
   (pad "41" smd rect (at -0.1 -1.94 180) (size 0.9 0.9) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp b024abe4-8216-4a32-93d4-84a8fee4c2b2))
   (pad "41" smd rect (at -0.1 -0.54 180) (size 0.9 0.9) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp 848cbf8f-7971-4160-b1cb-5ef5c5f778c1))
   (pad "41" smd rect (at -0.1 0.86 180) (size 0.9 0.9) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp 80bbc5b6-fa99-4be6-8706-175bfe844748))
-  (model "${KICAD7_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-S2-SOLO-U.STEP"
+  (model "${KICAD8_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-S2-SOLO-U.STEP"
     (offset (xyz -9 -9.75 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/footprints/Espressif.pretty/ESP32-S2-SOLO.kicad_mod
+++ b/footprints/Espressif.pretty/ESP32-S2-SOLO.kicad_mod
@@ -120,7 +120,7 @@
       )
     )
   )
-  (model "${KICAD7_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-S2-SOLO.STEP"
+  (model "${KICAD8_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-S2-SOLO.STEP"
     (offset (xyz -9 -9.75 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/footprints/Espressif.pretty/ESP32-S2-WROOM.kicad_mod
+++ b/footprints/Espressif.pretty/ESP32-S2-WROOM.kicad_mod
@@ -122,7 +122,7 @@
       )
     )
   )
-  (model "${KICAD7_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-S2-WROOM.STEP"
+  (model "${KICAD8_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-S2-WROOM.STEP"
     (offset (xyz -9 18.65 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/footprints/Espressif.pretty/ESP32-S2-WROVER.kicad_mod
+++ b/footprints/Espressif.pretty/ESP32-S2-WROVER.kicad_mod
@@ -126,7 +126,7 @@
       )
     )
   )
-  (model "${KICAD7_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-S2-WROVER.STEP"
+  (model "${KICAD8_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-S2-WROVER.STEP"
     (offset (xyz -9 18.65 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/footprints/Espressif.pretty/ESP32-S3-MINI-1.kicad_mod
+++ b/footprints/Espressif.pretty/ESP32-S3-MINI-1.kicad_mod
@@ -169,7 +169,7 @@
       )
     )
   )
-  (model "${KICAD7_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-S3-MINI-1.STEP"
+  (model "${KICAD8_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-S3-MINI-1.STEP"
     (offset (xyz -7.7 -7.7 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/footprints/Espressif.pretty/ESP32-S3-MINI-1U.kicad_mod
+++ b/footprints/Espressif.pretty/ESP32-S3-MINI-1U.kicad_mod
@@ -147,7 +147,7 @@
   (pad "63" smd rect (at -7 7 180) (size 0.8 0.8) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp d67805db-387c-4a8f-839b-2a2e560f75e0))
   (pad "64" smd rect (at 7 7 180) (size 0.8 0.8) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp 19031a68-6f7c-490b-9ac3-1a0fb5922fa3))
   (pad "65" smd rect (at 7 -7 180) (size 0.8 0.8) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp a24a0705-005d-4cbc-bbba-22e741b077a1))
-  (model "${KICAD7_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-S3-MINI-1U.STEP"
+  (model "${KICAD8_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-S3-MINI-1U.STEP"
     (offset (xyz -7.7 -7.7 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/footprints/Espressif.pretty/ESP32-S3-WROOM-1.kicad_mod
+++ b/footprints/Espressif.pretty/ESP32-S3-WROOM-1.kicad_mod
@@ -122,7 +122,7 @@
       )
     )
   )
-  (model "${KICAD7_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-S3-WROOM-1.STEP"
+  (model "${KICAD8_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-S3-WROOM-1.STEP"
     (opacity 0.7500)    (offset (xyz -9 -9.75 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/footprints/Espressif.pretty/ESP32-S3-WROOM-1U.kicad_mod
+++ b/footprints/Espressif.pretty/ESP32-S3-WROOM-1U.kicad_mod
@@ -87,7 +87,7 @@
   (pad "41" smd rect (at -0.1 -1.94 180) (size 0.9 0.9) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp d54fa077-c2ff-4eea-b648-1196b267c6d8))
   (pad "41" smd rect (at -2.9 0.86 180) (size 0.9 0.9) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp dd462884-daa4-41ad-96c7-69385fea5293))
   (pad "41" smd rect (at -1.5 -0.54 180) (size 0.9 0.9) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp de01120d-7504-4a2f-a552-ced0351d2228))
-  (model "${KICAD7_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-S3-WROOM-1U.STEP"
+  (model "${KICAD8_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-S3-WROOM-1U.STEP"
     (offset (xyz -9 -9.75 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/footprints/Espressif.pretty/ESP32-S3-WROOM-2.kicad_mod
+++ b/footprints/Espressif.pretty/ESP32-S3-WROOM-2.kicad_mod
@@ -122,7 +122,7 @@
       )
     )
   )
-  (model "${KICAD7_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-S3-WROOM-1.STEP"
+  (model "${KICAD8_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-S3-WROOM-1.STEP"
     (opacity 0.7500)    (offset (xyz -9 -9.75 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/footprints/Espressif.pretty/ESP32-WROOM-32E.kicad_mod
+++ b/footprints/Espressif.pretty/ESP32-WROOM-32E.kicad_mod
@@ -125,7 +125,7 @@
       )
     )
   )
-  (model "${KICAD7_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-WROOM-32E.STEP"
+  (model "${KICAD8_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-WROOM-32E.STEP"
     (opacity 0.7900)    (offset (xyz -9.01 -11 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/footprints/Espressif.pretty/ESP32-WROOM-32UE.kicad_mod
+++ b/footprints/Espressif.pretty/ESP32-WROOM-32UE.kicad_mod
@@ -85,7 +85,7 @@
   (pad "39" smd rect (at -1.5 -2.47 180) (size 0.9 0.9) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp c8a7af6e-c432-4fa3-91ee-c8bf0c5a9ebe))
   (pad "39" smd rect (at -0.1 -2.47 180) (size 0.9 0.9) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp d01102e9-b170-4eb1-a0a4-9a31feb850b7))
   (pad "39" smd rect (at -0.1 0.33 180) (size 0.9 0.9) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp fe14c012-3d58-4e5e-9a37-4b9765a7f764))
-  (model "${KICAD7_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-WROOM-32UE.STEP"
+  (model "${KICAD8_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-WROOM-32UE.STEP"
     (offset (xyz -9 -9.6 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/footprints/Espressif.pretty/ESP32-WROVER-E.kicad_mod
+++ b/footprints/Espressif.pretty/ESP32-WROVER-E.kicad_mod
@@ -112,7 +112,7 @@
       )
     )
   )
-  (model "${KICAD7_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-WROVER-E.STEP"
+  (model "${KICAD8_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-WROVER-E.STEP"
     (offset (xyz -9 -15.7 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/footprints/Espressif.pretty/ESP32-WROVER-E_ThermalVias.kicad_mod
+++ b/footprints/Espressif.pretty/ESP32-WROVER-E_ThermalVias.kicad_mod
@@ -124,7 +124,7 @@
       )
     )
   )
-  (model "${KICAD7_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-WROVER-E.STEP"
+  (model "${KICAD8_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-WROVER-E.STEP"
     (offset (xyz -9 -15.7 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/metadata.json
+++ b/metadata.json
@@ -23,15 +23,6 @@
     },
     "versions": [
         {
-            "version": "2.0.8",
-            "status": "stable",
-            "kicad_version": "7.0.0",
-            "download_sha256": "57fa76e704e43446423f15c9c1e1808c315b6e4f3daaee43eb5ae1a561e9abac",
-            "download_size": 47920075,
-            "download_url": "https://github.com/espressif/kicad-libraries/releases/download/2.0.8/espressif-kicad-addon.zip",
-            "install_size": 230040813
-        },
-        {
             "version": "2.07",
             "status": "stable",
             "kicad_version": "7.0.0",

--- a/metadata.json
+++ b/metadata.json
@@ -23,6 +23,15 @@
     },
     "versions": [
         {
+            "version": "2.0.8",
+            "status": "stable",
+            "kicad_version": "7.0.0",
+            "download_sha256": "57fa76e704e43446423f15c9c1e1808c315b6e4f3daaee43eb5ae1a561e9abac",
+            "download_size": 47920075,
+            "download_url": "https://github.com/espressif/kicad-libraries/releases/download/2.0.8/espressif-kicad-addon.zip",
+            "install_size": 230040813
+        },
+        {
             "version": "2.07",
             "status": "stable",
             "kicad_version": "7.0.0",


### PR DESCRIPTION
This updates the references to the 3D models so that they are correct for KiCad 8.

Fixes #153 

- [x] Create the **legacy-kicad7** branch

NOTE - before merging this a legacy branch will need to be created so that KiCad 7 is still supported.