### PR TITLE
Fix model paths of ESP32-C6-WROOM-1U and QFN-32-1EP_4x4mm_P0.4mm_EP2.9x2.9mm

### DIFF
--- a/footprints/Espressif.pretty/ESP32-C6-WROOM-1U.kicad_mod
+++ b/footprints/Espressif.pretty/ESP32-C6-WROOM-1U.kicad_mod
@@ -82,7 +82,7 @@
   (pad "29" smd rect (at -0.255 -3.79 180) (size 0.8 0.8) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp 325964ac-707a-4db9-9457-88ae8b311329))
   (pad "29" smd rect (at -0.255 -2.54 180) (size 0.8 0.8) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp 8d57aefc-46be-46ca-9783-caa0625b0b06))
   (pad "29" smd rect (at -0.255 -1.29 180) (size 0.8 0.8) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp af66518f-af54-48c0-b506-27977596c4f8))
-  (model "${KICAD7_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-C6-WROOM-1U.STEP"
+  (model "${KICAD8_3RD_PARTY}/3dmodels/com_github_espressif_kicad-libraries/espressif.3dshapes/ESP32-C6-WROOM-1U.STEP"
     (offset (xyz -9 -9.75 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/footprints/Espressif.pretty/QFN-32-1EP_4x4mm_P0.4mm_EP2.9x2.9mm.kicad_mod
+++ b/footprints/Espressif.pretty/QFN-32-1EP_4x4mm_P0.4mm_EP2.9x2.9mm.kicad_mod
@@ -84,7 +84,7 @@
   (pad "31" smd roundrect (at -1 -2) (size 0.2 0.7) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (tstamp 0de95550-0e28-4286-aa0b-3df0540ec2a4))
   (pad "32" smd roundrect (at -1.4 -2) (size 0.2 0.7) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (tstamp ec563b05-aadc-42dc-9412-1fc515f97476))
   (pad "33" smd rect (at 0 0) (size 2.8 2.8) (layers "F.Cu" "F.Mask") (tstamp e7dfe5e5-7399-4306-b868-49a7d038de04))
-  (model "${KICAD6_3DMODEL_DIR}/Package_DFN_QFN.3dshapes/QFN-32-1EP_4x4mm_P0.4mm_EP2.9x2.9mm.wrl"
+  (model "${KICAD8_3DMODEL_DIR}/Package_DFN_QFN.3dshapes/QFN-32-1EP_4x4mm_P0.4mm_EP2.9x2.9mm.wrl"
     (offset (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))


### PR DESCRIPTION
- Update ESP32-C6-WROOM-1U footprint model for KiCad 8  
  Amends #154
- Use KiCad 8 model directory for QFN-32-1EP_4x4mm_P0.4mm_EP2.9x2.9mm  
  Amends #154 and #129.  

I have checked all other model paths and confirmed they exist.

I'll backport the QNF-32 footprint model change to the KiCad 7 branch.