### PR TITLE
Fixed ESP32-C5 module GND pin

### DIFF
--- a/symbols/Espressif.kicad_sym
+++ b/symbols/Espressif.kicad_sym
@@ -5181,6 +5181,7 @@
 			(pin passive line
 				(at 0 -26.67 90)
 				(length 2.54)
+				(hide yes)
 				(name "GND"
 					(effects
 						(font
@@ -6475,7 +6476,7 @@
 			)
 		)
 		(property "Footprint" "PCM_Espressif:ESP32-C5-WROOM-1"
-			(at 19.558 -22.606 0)
+			(at 19.558 -21.971 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6522,7 +6523,7 @@
 		(symbol "ESP32-C5-WROOM-1_0_1"
 			(rectangle
 				(start -27.94 22.86)
-				(end 27.94 -20.955)
+				(end 27.94 -20.32)
 				(stroke
 					(width 0.254)
 					(type default)
@@ -6816,7 +6817,7 @@
 				)
 			)
 			(pin power_in line
-				(at 0 -23.495 90)
+				(at 0 -22.86 90)
 				(length 2.54)
 				(name "GND"
 					(effects
@@ -6834,7 +6835,7 @@
 				)
 			)
 			(pin passive line
-				(at 0 -23.495 90)
+				(at 0 -22.86 90)
 				(length 2.54)
 				(hide yes)
 				(name "GND"
@@ -6853,7 +6854,7 @@
 				)
 			)
 			(pin passive line
-				(at 0 -23.495 90)
+				(at 0 -22.86 90)
 				(length 2.54)
 				(hide yes)
 				(name "GND"
@@ -7144,7 +7145,7 @@
 			)
 		)
 		(property "Footprint" "PCM_Espressif:ESP32-C5-WROOM-1U"
-			(at 19.558 -22.606 0)
+			(at 19.558 -21.971 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7191,7 +7192,7 @@
 		(symbol "ESP32-C5-WROOM-1U_0_1"
 			(rectangle
 				(start -27.94 22.86)
-				(end 27.94 -20.955)
+				(end 27.94 -20.32)
 				(stroke
 					(width 0.254)
 					(type default)
@@ -7221,7 +7222,7 @@
 				)
 			)
 			(pin passive line
-				(at 0 -23.495 90)
+				(at 0 -22.86 90)
 				(length 2.54)
 				(hide yes)
 				(name "GND"
@@ -7240,7 +7241,7 @@
 				)
 			)
 			(pin passive line
-				(at 0 -23.495 90)
+				(at 0 -22.86 90)
 				(length 2.54)
 				(hide yes)
 				(name "GND"
@@ -7543,7 +7544,7 @@
 				)
 			)
 			(pin power_in line
-				(at 0 -23.495 90)
+				(at 0 -22.86 90)
 				(length 2.54)
 				(name "GND"
 					(effects
@@ -7561,7 +7562,7 @@
 				)
 			)
 			(pin passive line
-				(at 0 -23.495 90)
+				(at 0 -22.86 90)
 				(length 2.54)
 				(hide yes)
 				(name "GND"
@@ -7580,7 +7581,7 @@
 				)
 			)
 			(pin passive line
-				(at 0 -23.495 90)
+				(at 0 -22.86 90)
 				(length 2.54)
 				(hide yes)
 				(name "GND"


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

This PR fixes the GND pin alignment on the grid for the ESP32-C5-WROOM modules.

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

Issue #197 

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
